### PR TITLE
Python/Django compatibility

### DIFF
--- a/access/admin.py
+++ b/access/admin.py
@@ -45,8 +45,10 @@ from django.apps import apps
 
 from access.managers import AccessManager
 
-from collections import abc as collections
-
+try:
+    from collections import Iterable
+except ImportError:
+    from collections.abs import Iterable
 
 
 def list_union(l1, l2):
@@ -254,7 +256,7 @@ class AccessControlMixin(object):
                 if fieldname.endswith("_set"):
                     fieldname = fieldname[:-4]
                 field = form.instance._meta.get_field(fieldname)
-                if isinstance(v, collections.Iterable) and not isinstance(v, string_types) and isinstance(field, ForeignObjectRel):
+                if isinstance(v, Iterable) and not isinstance(v, string_types) and isinstance(field, ForeignObjectRel):
                     continue
                 if getattr(obj, k) is None:
                     setattr(obj, k, v)
@@ -272,7 +274,7 @@ class AccessControlMixin(object):
                 if fieldname.endswith("_set"):
                     fieldname = fieldname[:-4]
                 field = form.instance._meta.get_field(fieldname)
-                if isinstance(v, collections.Iterable) and not isinstance(v, string_types) and isinstance(field, ForeignObjectRel):
+                if isinstance(v, Iterable) and not isinstance(v, string_types) and isinstance(field, ForeignObjectRel):
                     fld = getattr(form.instance, k)
                     for i in v:
                         fld.add(i)

--- a/access/admin.py
+++ b/access/admin.py
@@ -45,7 +45,8 @@ from django.apps import apps
 
 from access.managers import AccessManager
 
-import collections
+from collections import abc as collections
+
 
 
 def list_union(l1, l2):


### PR DESCRIPTION
Hi! I found one more incompatibility: 
Python 3.11
Django 4.1

The error occured: AttributeError: module 'collections' has no attribute 'Iterable', when i tried to return some dict in CheckAblePlugin in appendable. Please correct it as you wish.